### PR TITLE
Publishable Mixin: Cleanup, Fix, Improve

### DIFF
--- a/metadata/charcoal/object/publishable-interface.json
+++ b/metadata/charcoal/object/publishable-interface.json
@@ -35,7 +35,7 @@
             "input_type": "charcoal/admin/property/input/select",
             "label": {
                 "en": "Publication Status",
-                "fr": "Status de publication"
+                "fr": "Statut de publication"
             },
             "choices": {
                 "draft": {

--- a/src/Charcoal/Object/ObjectRoute.php
+++ b/src/Charcoal/Object/ObjectRoute.php
@@ -3,7 +3,6 @@ namespace Charcoal\Object;
 
 use DateTime;
 use DateTimeInterface;
-use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use Exception;

--- a/src/Charcoal/Object/PublishableInterface.php
+++ b/src/Charcoal/Object/PublishableInterface.php
@@ -2,45 +2,67 @@
 
 namespace Charcoal\Object;
 
+use DateTimeInterface;
+
 /**
- *
+ * Defines an object as publishable via date/time values and statuses.
  */
 interface PublishableInterface
 {
-    /**
-     * @param string|DateTime $publishDate The publish date.
-     * @return PublishableInterface Chainable
-     */
-    public function setPublishDate($publishDate);
+    const STATUS_DRAFT     = 'draft';
+    const STATUS_PENDING   = 'pending';
+    const STATUS_PUBLISHED = 'published';
+    const STATUS_UPCOMING  = 'upcoming';
+    const STATUS_EXPIRED   = 'expired';
 
     /**
+     * Set the object's publication date.
+     *
+     * @param  string|DateTimeInterface|null $time The date/time value.
+     * @return PublishableInterface Chainable
+     */
+    public function setPublishDate($time);
+
+    /**
+     * Retrieve the object's publication date.
+     *
      * @return \DateTimeInterface|null
      */
     public function publishDate();
 
     /**
-     * @param string|\DateTimeInterface $expiryDate The expiry date.
+     * Set the object's expiration date.
+     *
+     * @param  string|DateTimeInterface|null $time The date/time value.
      * @return PublishableInterface Chainable
      */
-    public function setExpiryDate($expiryDate);
+    public function setExpiryDate($time);
 
     /**
+     * Retrieve the object's expiration date.
+     *
      * @return \DateTimeInterface|null
      */
     public function expiryDate();
 
     /**
-     * @param string $status The publish status (can be draft, pending or published).
+     * Set the object's publication status.
+     *
+     * @param  string $status A publication status.
      * @return PublishableInterface Chainable
      */
     public function setPublishStatus($status);
 
     /**
+     * Retrieve the object's publication status.
+     *
      * @return string
      */
     public function publishStatus();
 
     /**
+     * Determine if the object is published.
+     *
      * @return boolean
      */
     public function isPublished();

--- a/tests/Charcoal/Object/Mocks/PublishableClass.php
+++ b/tests/Charcoal/Object/Mocks/PublishableClass.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Charcoal\Object\Tests\Mocks;
+
+// From 'charcoal-core'
+use Charcoal\Model\ModelInterface;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\TranslatorAwareTrait;
+
+// From 'charcoal-object'
+use Charcoal\Object\PublishableInterface;
+use Charcoal\Object\PublishableTrait;
+
+/**
+ *
+ */
+class PublishableClass implements
+    ModelInterface,
+    PublishableInterface
+{
+    use PublishableTrait;
+    use TranslatorAwareTrait;
+
+    private $id;
+
+    protected $metadata;
+
+    protected $modelFactory;
+
+    public function __construct(array $data = null)
+    {
+        $this->setModelFactory($data['factory']);
+        $this->setTranslator($data['translator']);
+
+        if (isset($data['id'])) {
+            $this->setId($data['id']);
+        }
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function id()
+    {
+        if ($this->id === null) {
+            $this->id = uniqid();
+        }
+
+        return $this->id;
+    }
+
+    public function key()
+    {
+        return 'id';
+    }
+
+    public function objType()
+    {
+        return 'charcoal/tests/object/publishable-class';
+    }
+
+    public function setModelFactory($factory)
+    {
+        $this->modelFactory = $factory;
+
+        return $this;
+    }
+
+    public function modelFactory()
+    {
+        return $this->modelFactory;
+    }
+
+    public function setMetadata($metadata)
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function metadata()
+    {
+        if ($this->metadata === null) {
+            return [];
+        }
+        return $this->metadata;
+    }
+
+    /**
+     * @param array $data The model data.
+     * @return ModelInterface Chainable
+     */
+    public function setData(array $data)
+    {
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function data()
+    {
+        return null;
+    }
+
+    /**
+     * @param array $data The odel flat data.
+     * @return ModelInterface Chainable
+     */
+    public function setFlatData(array $data)
+    {
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function flatData()
+    {
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function defaultData()
+    {
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function properties()
+    {
+        return null;
+    }
+
+    /**
+     * @param string $propertyIdent The property (ident) to get.
+     * @return PropertyInterface
+     */
+    public function property($propertyIdent)
+    {
+        return null;
+    }
+
+    /**
+     * Alias of `properties()` (if not parameter is set) or `property()`.
+     *
+     * @param string $propertyIdent The property (ident) to get.
+     * @return mixed
+     */
+    public function p($propertyIdent = null)
+    {
+        return null;
+    }
+}

--- a/tests/Charcoal/Object/PublishableTraitTest.php
+++ b/tests/Charcoal/Object/PublishableTraitTest.php
@@ -3,10 +3,16 @@
 namespace Charcoal\Object\Tests;
 
 use DateTime;
+use InvalidArgumentException;
+use UnexpectedValueException;
+
+// From Pimple
+use Pimple\Container;
 
 // From 'charcoal-object'
 use Charcoal\Object\PublishableTrait;
 use Charcoal\Object\Tests\ContainerProvider;
+use Charcoal\Object\Tests\Mocks\PublishableClass as PublishableObject;
 
 /**
  *
@@ -21,71 +27,127 @@ class PublishableTraitTest extends \PHPUnit_Framework_TestCase
     private $obj;
 
     /**
+     * Store the service container.
+     *
+     * @var Container
+     */
+    private $container;
+
+    /**
      * Set up the test.
      */
     public function setUp()
     {
-        $this->obj = $this->getMockForTrait(PublishableTrait::class);
+        $container = $this->container();
+
+        $this->obj = new PublishableObject([
+            'factory'    => $container['model/factory'],
+            'translator' => $container['translator']
+        ]);
     }
 
     /**
      * Assert that the `setPublishDate` method:
      * - is chainable
-     * - sets the publishDate value when a string is passed
-     * - sets the publishDate value when a DateTime is passed
-     * - throws an InvalidArgumentException if other types of arguments are passed
+     * - accepts a string representation of a date/time value
+     * - accepts a {@see \DateTimeInterface}
+     * - accepts an blank value
      */
-    public function testSetPublishDate()
+    public function testPublishDate()
     {
-        $obj = $this->obj;
-        $dt = new DateTime('2015-01-01 00:00:00');
+        $obj  = $this->obj;
+        $time = new DateTime('2015-01-01 00:00:00');
 
         $ret = $obj->setPublishDate('2015-01-01 00:00:00');
         $this->assertSame($ret, $obj);
-        $this->assertEquals($dt, $obj->publishDate());
+        $this->assertEquals($time, $obj->publishDate());
 
-        $obj->setPublishDate($dt);
-        $this->assertEquals($dt, $obj->publishDate());
+        $obj->setPublishDate('');
+        $this->assertEquals(null, $obj->publishDate());
 
-        $this->setExpectedException('\InvalidArgumentException');
-        $obj->setPublishDate(false);
+        $obj->setPublishDate($time);
+        $this->assertEquals($time, $obj->publishDate());
     }
 
+    public function testUnexpectedPublishDate()
+    {
+        $obj = $this->obj;
+
+        $this->setExpectedException(UnexpectedValueException::class);
+        $obj->setPublishDate('foobar');
+    }
+
+    public function testInvalidPublishDate()
+    {
+        $obj = $this->obj;
+
+        $this->setExpectedException(InvalidArgumentException::class);
+        $obj->setPublishDate(false);
+    }
 
     /**
      * Assert that the `setExpiryDate` method:
      * - is chainable
-     * - sets the expiryDate value when a string is passed
-     * - sets the expiryDate value when a DateTime is passed
-     * - throws an InvalidArgumentException if other types of arguments are passed
+     * - accepts a string representation of a date/time value
+     * - accepts a {@see \DateTimeInterface}
+     * - accepts an blank value
      */
-    public function testSetExpiryDate()
+    public function testExpiryDate()
     {
-        $obj = $this->obj;
-        $dt = new DateTime('2015-01-01 00:00:00');
+        $obj  = $this->obj;
+        $time = new DateTime('2015-01-01 00:00:00');
 
         $ret = $obj->setExpiryDate('2015-01-01 00:00:00');
         $this->assertSame($ret, $obj);
-        $this->assertEquals($dt, $obj->expiryDate());
+        $this->assertEquals($time, $obj->expiryDate());
 
-        $obj->setExpiryDate($dt);
-        $this->assertEquals($dt, $obj->expiryDate());
+        $obj->setExpiryDate('');
+        $this->assertEquals(null, $obj->expiryDate());
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $obj->setExpiryDate($time);
+        $this->assertEquals($time, $obj->expiryDate());
+    }
+
+    public function testUnexpectedExpiryDate()
+    {
+        $obj = $this->obj;
+
+        $this->setExpectedException(UnexpectedValueException::class);
+        $obj->setExpiryDate('foobar');
+    }
+
+    public function testInvalidExpiryDate()
+    {
+        $obj = $this->obj;
+
+        $this->setExpectedException(InvalidArgumentException::class);
         $obj->setExpiryDate(false);
     }
 
-    public function testSetPublishStatus()
+    public function testPublishStatus()
     {
         $obj = $this->obj;
         $obj->setPublishStatus('draft');
         $this->assertEquals('draft', $obj->publishStatus());
+
         $obj->setPublishStatus('pending');
         $this->assertEquals('pending', $obj->publishStatus());
+
         $obj->setPublishStatus('published');
         $this->assertEquals('published', $obj->publishStatus());
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $obj->setPublishStatus('upcoming');
+        $this->assertEquals('published', $obj->publishStatus());
+
+        $obj->setPublishStatus('expired');
+        $this->assertEquals('published', $obj->publishStatus());
+
+        $obj->setPublishDate(null);
+        $obj->setExpiryDate(null);
+        $obj->setPublishStatus('');
+        $this->assertEquals(null, $obj->publishStatus());
+
+        $this->setExpectedException(InvalidArgumentException::class);
         $obj->setPublishStatus('foobar');
     }
 
@@ -104,6 +166,7 @@ class PublishableTraitTest extends \PHPUnit_Framework_TestCase
 
         $obj->setPublishStatus('draft');
         $this->assertEquals('draft', $obj->publishStatus());
+
         $obj->setPublishStatus('pending');
         $this->assertEquals('pending', $obj->publishStatus());
 
@@ -117,8 +180,8 @@ class PublishableTraitTest extends \PHPUnit_Framework_TestCase
             [ null, null, 'published' ],
             [ 'yesterday', 'tomorrow', 'published' ],
             [ '2 days ago', 'yesterday', 'expired' ],
-            [ 'tomorrow', '+1 week', 'pending' ],
-            [ 'tomorrow', null, 'pending' ],
+            [ 'tomorrow', '+1 week', 'upcoming' ],
+            [ 'tomorrow', null, 'upcoming' ],
             [ null, 'tomorrow', 'published' ],
             [ null, 'yesterday', 'expired' ]
         ];
@@ -127,7 +190,11 @@ class PublishableTraitTest extends \PHPUnit_Framework_TestCase
     public function testIsPublished()
     {
         $obj = $this->obj;
-        $this->assertTrue($obj->isPublished());
+
+        $obj->setPublishDate(null);
+        $obj->setExpiryDate(null);
+        $obj->setPublishStatus(null);
+        $this->assertFalse($obj->isPublished());
 
         $obj->setPublishStatus('draft');
         $this->assertFalse($obj->isPublished());
@@ -135,7 +202,30 @@ class PublishableTraitTest extends \PHPUnit_Framework_TestCase
         $obj->setPublishStatus('published');
         $this->assertTrue($obj->isPublished());
 
+        $obj->setPublishDate('tomorrow');
+        $this->assertFalse($obj->isPublished());
+
         $obj->setExpiryDate('yesterday');
         $this->assertFalse($obj->isPublished());
+    }
+
+    /**
+     * Set up the service container.
+     *
+     * @return Container
+     */
+    private function container()
+    {
+        if ($this->container === null) {
+            $container = new Container();
+            $containerProvider = new ContainerProvider();
+            $containerProvider->registerBaseServices($container);
+            $containerProvider->registerModelFactory($container);
+            $containerProvider->registerModelCollectionLoader($container);
+
+            $this->container = $container;
+        }
+
+        return $this->container;
     }
 }


### PR DESCRIPTION
Changes:
- Fixed `PublishableTrait::publishDateStatus()` returning “pending” instead of “upcoming”;
- Added constants for the default statuses;
- Fixed handling of special statuses;
- Improved handling of date/time values;
- Cleanup Publishable documentation;
- Updated unit tests (added mock class);