### PR TITLE
Replace is_countable function

### DIFF
--- a/src/Charcoal/Object/CategoryTrait.php
+++ b/src/Charcoal/Object/CategoryTrait.php
@@ -68,7 +68,7 @@ trait CategoryTrait
     public function numCategoryItems()
     {
         $items = $this->categoryItems();
-        return is_countable($items) ? count($items) : 0;
+        return (is_array($items) || ($items instanceof \Countable)) ? count($items) : 0;
     }
 
     /**


### PR DESCRIPTION
The `is_countable()` function is only available in PHP 7.3.
Replacing it with classic `is_array()` and `instanceof Countable`.